### PR TITLE
Fix Pathing issue with install script, pre-commit linting script

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -2,7 +2,7 @@
 
 for file in $(git diff --cached --name-only | grep -E '\.ts$')
 do
-    git show ":$file" | tslint "$file"
+    git show ":$file" | $(npm bin)/tslint "$file"
     if [ $? -ne 0 ]; then
         exit 1
     fi

--- a/git-hooks/wrapper
+++ b/git-hooks/wrapper
@@ -3,7 +3,7 @@ if [ -x $0.local ]; then
     $0.local "$@" || exit $?
 fi
 
-HOOK_TO_RUN=$(pwd)/node_modules/ddts/git-hooks/$(basename $0)
+HOOK_TO_RUN=$(git rev-parse --show-toplevel)/node_modules/ddts/git-hooks/$(basename $0)
 
 if [ -x $HOOK_TO_RUN ]; then
     $HOOK_TO_RUN "$@" || exit $?

--- a/git-hooks/wrapper
+++ b/git-hooks/wrapper
@@ -3,6 +3,8 @@ if [ -x $0.local ]; then
     $0.local "$@" || exit $?
 fi
 
-if [ -x $(basename $0) ]; then
-    $(basename $0) "$@" || exit $?
+HOOK_TO_RUN=$(pwd)/node_modules/ddts/git-hooks/$(basename $0)
+
+if [ -x $HOOK_TO_RUN ]; then
+    $HOOK_TO_RUN "$@" || exit $?
 fi

--- a/install-hooks
+++ b/install-hooks
@@ -1,7 +1,8 @@
 #!/bin/bash
 HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-receive update post-receive post-update pre-auto-gc"
-PARENT_HOOKS=$(git rev-parse --show-toplevel)/.git/hooks
-REPLACEMENT_HOOKS=$(pwd)/git-hooks
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+PARENT_HOOKS=$PROJECT_ROOT/.git/hooks
+REPLACEMENT_HOOKS=$PROJECT_ROOT/node_modules/ddts/git-hooks
 
 for hook in $HOOK_NAMES; do
     if [ -f $REPLACEMENT_HOOKS/$hook ]; then

--- a/install-hooks
+++ b/install-hooks
@@ -1,15 +1,16 @@
 #!/bin/bash
 HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-receive update post-receive post-update pre-auto-gc"
 PARENT_HOOKS=$(git rev-parse --show-toplevel)/.git/hooks
+REPLACEMENT_HOOKS=$(pwd)/git-hooks
 
 for hook in $HOOK_NAMES; do
-    if [ -f ./git-hooks/$hook ]; then
+    if [ -f $REPLACEMENT_HOOKS/$hook ]; then
         # If the hook already exists, is executable, and is not a symlink
         if [ ! -h $PARENT_HOOKS/$hook -a -x $PARENT_HOOKS/$hook ]; then
             mv $PARENT_HOOKS/$hook $PARENT_HOOKS/$hook.local
         fi
-        
+
         # create the symlink, overwriting the file if it exists
-        ln -s -f ./git-hooks/wrapper $PARENT_HOOKS/$hook
+        ln -s -f $REPLACEMENT_HOOKS/wrapper $PARENT_HOOKS/$hook
     fi
 done

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "tslint.json",
   "scripts": {
     "postinstall": "./install-hooks"


### PR DESCRIPTION
- `tslint` is a node module binary, so needs to be called from `$(npm bin)/`
- git hooks are run from `<path to project>/.git/hooks/`, so symlinked wrapper needs more absolute pathing (i.e. `$REPLACEMENT_HOOKS`)