### PR TITLE
Added no property mutation rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+rules/*.js

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "0.0.8",
   "main": "tslint.json",
   "scripts": {
-    "postinstall": "./install-hooks"
+    "postinstall": "npm run compilerules; ./install-hooks",
+    "compilerules": "$(git rev-parse --show-toplevel)/node_modules/.bin/tsc ./rules/*.ts || true"
   },
   "description": "A typescript style guide with teeth",
   "author": "Connor Harwood <charwood@dronedeploy.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "peerDependency": {
+    "typescript": "^2.3.4"
+  }
 }

--- a/rules/noPropertyMutationRule.ts
+++ b/rules/noPropertyMutationRule.ts
@@ -1,0 +1,23 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new NoPropertyMutation(sourceFile, this.getOptions()));
+  }
+}
+
+const isAssigningProperty = (node) => node.parent.left === node && node.parent.operatorToken.getText() === '=';
+const accessorIsNotOnThis = (node) => node.expression.getText() !== 'this';
+
+class NoPropertyMutation extends Lint.RuleWalker {
+  public visitPropertyAccessExpression(node) {
+    if (isAssigningProperty(node) && accessorIsNotOnThis(node)) {
+      const errorMessage = 'Object mutation is not allowed. Please use the spread operator and create a new object';
+      this.addFailure(this.createFailure(node.getStart(), node.getWidth(), errorMessage));
+    }
+
+    // call the base version of this visitor to actually parse this node
+    super.walkChildren(node);
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,7 @@
 {
+  "rulesDirectory": [
+    "./rules/"
+  ],
   "rules": {
     "align": [
       true,
@@ -53,6 +56,7 @@
     "no-default-export": true,
     "no-eval": true,
     "no-inferrable-types": [true, "ignore-params"],
+    "no-property-mutation": true,
     "no-require-imports": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,


### PR DESCRIPTION
<img width="812" alt="screen shot 2017-06-01 at 3 49 58 pm" src="https://cloud.githubusercontent.com/assets/4013767/26703416/cadec3ae-46e6-11e7-91b9-79efc9964357.png">

- Will catch object.someproperty = 3 and recommend object = { ...object, someproperty: 3}
- Does not enforce property mutation on class instance variables (I.E this.num = 3 will pass)