### PR TITLE
add tslint --fix and strict compile to lint staged

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -2,6 +2,8 @@
   "*.ts": [
     "prettier --write --config ./node_modules/ddts/.prettierrc.yml",
     "git add",
-    "tslint"
+    "tslint --fix",
+    "git add",
+    "ddts-strict-compile"
   ]
 }

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 $(npm bin)/lint-staged -c ./node_modules/ddts/.lintstagedrc || exit 1
-$(npm bin)/ddts-strict-compile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddts",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "tslint.json",
   "scripts": {
     "postinstall": "npm run compilerules; ./install-hooks",


### PR DESCRIPTION
Add the `--fix` param to tslint just in case there are conflicting rules between prettier and tslint. Also allows us to autofix stuff that's not covered by prettier (import sorting, etc).

Also moved `ddts-strict-compile` into lint-staged so we can see what's happening during pre-commit.