### PR TITLE
Update .prettierrc.yml

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,5 +1,5 @@
 printWidth: 100
-parser: typescript
+parser: 'typescript'
 tabWidth: 2
 useTabs: false
 semi: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "tslint.json",
   "scripts": {
     "postinstall": "npm run compilerules; ./install-hooks",


### PR DESCRIPTION
Changing this value to a string allows my vscode prettier plugin to work. 
I believe the prettier docs say this value should be a string too
https://prettier.io/docs/en/options.html#parser