### PR TITLE
Allow double leading underscores for property names

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,7 +40,7 @@
           "regex": "^[-]",
           "match": true
         },
-        "leadingUnderscore": "allow"
+        "leadingUnderscore": "allowSingleOrDouble"
       }
     ],
     "@typescript-eslint/no-explicit-any": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddts",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": ".eslintrc.json",
   "scripts": {
     "postinstall": "./install-hooks"


### PR DESCRIPTION
# Work Done
- Updated `@typescript-eslint/naming-convention` rule to also allow double leading underscores for property names
  - Right now we already (apparently?) allow a single leading underscore (e.g. `_myprop`)
  - We can make this more strict by only allowing a "__typename" regex match with `filter`, but for now it might be okay. We have a couple instances of other property names in our codebase that have a double underscore in front. If it gets out of control, we can revisit and only allow certain names.

## Reason
Mainly to allow `__typename` properties (used for GQL types, file types, etc.) without having to add an ignore line for each instance

## References
- Documentation here: https://typescript-eslint.io/rules/naming-convention/