### PR TITLE
Fix pre-commit command for newer versions of node

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$(npm bin)/lint-staged -c ./node_modules/ddts/.lintstagedrc || exit 1
+npx lint-staged -c ./node_modules/ddts/.lintstagedrc || exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddts",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": ".eslintrc.json",
   "scripts": {
     "postinstall": "./install-hooks"


### PR DESCRIPTION
As it says in the title. The npm bin command causes problems with newer node version, which breaks commit hooks.

Details:
https://dronedeploy.slack.com/archives/C2TK3QEQ2/p1679086992164889
https://gist.github.com/jlabath/1517ea63c7a89be17aa9c1bc1ec9b41a#pre-commit-hook-fails-with-command-not-found